### PR TITLE
Clip Input 2.0.10

### DIFF
--- a/ClipInput.Client/ClipInput.Client.csproj
+++ b/ClipInput.Client/ClipInput.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<Version>2.0.9</Version>
+		<Version>2.0.10</Version>
 		<TargetFramework>net7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/ClipInput.Client/ClipInput.Client.csproj
+++ b/ClipInput.Client/ClipInput.Client.csproj
@@ -17,7 +17,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="GbxToolAPI.Client" Version="1.0.1" />
+		<PackageReference Include="GbxToolAPI.Client" Version="1.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ClipInput/ClipInput.csproj
+++ b/ClipInput/ClipInput.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="GbxToolAPI" Version="1.0.6" />
+	  <PackageReference Include="GbxToolAPI" Version="1.0.7" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ClipInput/ClipInput.csproj
+++ b/ClipInput/ClipInput.csproj
@@ -5,7 +5,7 @@
 		<AssemblyTitle>Clip Input 2</AssemblyTitle>
 		<Authors>Petr 'BigBang1112' Pivoňka</Authors>
 		<Copyright>Copyright © Petr 'BigBang1112' Pivoňka</Copyright>
-		<Version>2.0.9</Version>
+		<Version>2.0.10</Version>
 		<IsTrimmable>true</IsTrimmable>
 	</PropertyGroup>
 

--- a/ClipInputCLI/ClipInputCLI.csproj
+++ b/ClipInputCLI/ClipInputCLI.csproj
@@ -5,7 +5,7 @@
 		<AssemblyTitle>Clip Input 2 CLI</AssemblyTitle>
 		<Authors>Petr 'BigBang1112' Pivoňka</Authors>
 		<Copyright>Copyright © Petr 'BigBang1112' Pivoňka</Copyright>
-		<Version>2.0.9</Version>
+		<Version>2.0.10</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/ClipInputCLI/ClipInputCLI.csproj
+++ b/ClipInputCLI/ClipInputCLI.csproj
@@ -26,7 +26,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GbxToolAPI.CLI" Version="1.0.10" />
+		<PackageReference Include="GbxToolAPI.CLI" Version="1.0.11" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Updated GBX.NET to 1.2.4, fixing recent TM2020 input problems