### PR TITLE
Clip Input 2.0.11

### DIFF
--- a/ClipInput.Client/ClipInput.Client.csproj
+++ b/ClipInput.Client/ClipInput.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<Version>2.0.10</Version>
+		<Version>2.0.11</Version>
 		<TargetFramework>net7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/ClipInput/ClipInput.csproj
+++ b/ClipInput/ClipInput.csproj
@@ -5,7 +5,7 @@
 		<AssemblyTitle>Clip Input 2</AssemblyTitle>
 		<Authors>Petr 'BigBang1112' Pivoňka</Authors>
 		<Copyright>Copyright © Petr 'BigBang1112' Pivoňka</Copyright>
-		<Version>2.0.10</Version>
+		<Version>2.0.11</Version>
 		<IsTrimmable>true</IsTrimmable>
 	</PropertyGroup>
 
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="GbxToolAPI" Version="1.0.7" />
+	  <PackageReference Include="GbxToolAPI" Version="1.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ClipInputCLI/ClipInputCLI.csproj
+++ b/ClipInputCLI/ClipInputCLI.csproj
@@ -5,7 +5,7 @@
 		<AssemblyTitle>Clip Input 2 CLI</AssemblyTitle>
 		<Authors>Petr 'BigBang1112' Pivoňka</Authors>
 		<Copyright>Copyright © Petr 'BigBang1112' Pivoňka</Copyright>
-		<Version>2.0.10</Version>
+		<Version>2.0.11</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -26,7 +26,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GbxToolAPI.CLI" Version="1.0.11" />
+		<PackageReference Include="GbxToolAPI.CLI" Version="1.0.12" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Updated GBX.NET to 1.2.6, fixing autosave replay problems in TM2020